### PR TITLE
fix compiler warning about parens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ stamp-h1
 # binaries
 corkscrew
 *.o
+.*.swp
+.*.swo

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ stamp-h1
 # binaries
 corkscrew
 *.o
+.*.swp

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
 Pat Padgett <agroman@agroman.net>
 Bryan Chan <bryanpkc@gmail.com>
 Rémy Sanchez <remy@delos.ltd>
+Chad S. Lauritsen <csl4jc@gmail.com>

--- a/corkscrew.c
+++ b/corkscrew.c
@@ -184,7 +184,7 @@ char *argv[];
 
 	port = 80;
 
-	if ((argc == 5) || (argc == 6)) {
+	if (argc == 5 || argc == 6) {
 		if (argc == 5) {
 			host = argv[1];
 			port = atoi(argv[2]);
@@ -192,7 +192,7 @@ char *argv[];
 			destport = argv[4];
 			up = getenv("CORKSCREW_AUTH");
 		}
-		if ((argc == 6)) {
+		if (argc == 6) {
 			host = argv[1];
 			port = atoi(argv[2]);
 			desthost = argv[3];

--- a/corkscrew.c
+++ b/corkscrew.c
@@ -256,6 +256,7 @@ char *argv[];
 				if (len<=0)
 					break;
 				else {
+					memset(descr, 0, sizeof(descr));
 					sscanf(buffer,"%s%d%[^\n]",version,&code,descr);
 					if ((strncmp(version,"HTTP/",5) == 0) && (code >= 200) && (code < 300))
 						setup = 1;


### PR DESCRIPTION
# OS X Warning
Compiling on osx had this warning:
<img width="1153" alt="image" src="https://user-images.githubusercontent.com/4185468/49400341-fe6f1e80-f711-11e8-959f-b12b111e09da.png">

# Valgrind Warnings
Valgrind noted a printf of an uninitialized value, descr in fprintf.
<img width="651" alt="image" src="https://user-images.githubusercontent.com/4185468/49401628-b94ceb80-f715-11e8-82f0-ed75443147b2.png">

It also noted a memory leak, but that is a bigger change for another pull (#5).
