### PR TITLE
added install step for autoconf

### DIFF
--- a/README
+++ b/README
@@ -46,6 +46,10 @@ First you need to install development tools:
     # For Red-Hat-based distributions (CentOS, Fedora, ...)
     sudo yum groupinstall 'Development tools'
 
+    # For MacOS
+    brew install autoconf
+    brew install automake
+
 You need to clone the repo and then you need to go into the corkscrew
 source directory and run
 

--- a/README
+++ b/README
@@ -41,6 +41,7 @@ First you need to install development tools:
 
     # For Debian-based distributions (Ubuntu, ElementaryOS, ...)
     sudo apt install build-essential
+    sudo apt-get install -y autoconf
 
     # For Red-Hat-based distributions (CentOS, Fedora, ...)
     sudo yum groupinstall 'Development tools'


### PR DESCRIPTION
1. Just went through the steps to build on a fresh docker container `FROM ubuntu:18.04` and the`autoreconf --install` step fails without this package.
2. Pushed an additional commit with pre-install steps for macOS