### PR TITLE
docs: fix simple typo, usename -> username

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ in the command line.
 
 ## How Do I Use The HTTP Authentication Feature?
 
-You will need to create a file that contains your usename and password
+You will need to create a file that contains your username and password
 in the form of:
 
 ```text


### PR DESCRIPTION
There is a small typo in README.md.

Should read `username` rather than `usename`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md