### PR TITLE
Update corkscrew.c

### DIFF
--- a/corkscrew.c
+++ b/corkscrew.c
@@ -242,7 +242,7 @@ char *argv[];
 			FD_SET(csock, &sfd);
 		}
 		FD_SET(csock, &rfd);
-		FD_SET(0, &rfd);
+		if (setup) FD_SET(0, &rfd);
 
 		tv.tv_sec = 5;
 		tv.tv_usec = 0;
@@ -262,9 +262,9 @@ char *argv[];
 						setup = 1;
 					else {
 						if ((strncmp(version,"HTTP/",5) == 0) && (code >= 407)) {
+							fprintf(stderr, "Proxy could not open connection to %s: %s\n", desthost, descr);
+							exit(-1);
 						}
-						fprintf(stderr, "Proxy could not open connection to %s: %s\n", desthost, descr);
-						exit(-1);
 					}
 				}
 			}


### PR DESCRIPTION
Always setting stdin (fd 0) into &rfd causes select() to return immediately during the connecting phase as incoming data from stdin is not read until setup completes. This causes corkscrew to iterate at 100% CPU in the for(;;) loop until connection succeeds. Only allowing stdin into select() when we're already connected is done by checking for the setup variable.
Also, curly brace was mistakenly closed immediately at connect error check.